### PR TITLE
base-files: mkdir /factory

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,1 +1,5 @@
 FILESEXTRAPATHS_prepend_edison := "${THISDIR}/base-files:"
+
+do_install_append () {
+    install -m 755 -d ${D}/factory
+}


### PR DESCRIPTION
Create a mount point for factory. If /factory does not exist, and / is mounted read-only, the boot process will fail.