### PR TITLE
Use new serial console names (on master branch)

### DIFF
--- a/recipes-bsp/u-boot/files/edison.env
+++ b/recipes-bsp/u-boot/files/edison.env
@@ -11,7 +11,7 @@ do_dfu_alt_info_ifwi=setenv dfu_alt_info "ifwi${hardware_id} raw 0 8192 mmcpart 
 dfu_alt_info_reset=reset ram 0x0 0x0
 
 # Kernel load configuration
-bootargs_console=console=ttyMFD2 earlyprintk=ttyMFD2,keep
+bootargs_console=console=tty1 console=ttyS2,115200n8
 bootargs_debug=loglevel=4
 do_bootargs_rootfs=setenv bootargs_rootfs rootwait root=${rootfs} rootfstype=ext4
 first_install_retry=0


### PR DESCRIPTION
…el edison

When switching to vanilla kernel 4.x we need to use the standard serial console names

Signed-off-by: Florin Sarbu <florin@resin.io>