### PR TITLE
Add experimental bluez5 features (on master branch)

### DIFF
--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_append = " experimental"

--- a/recipes-kernel/bcm43340/bcm43340-fw.bb
+++ b/recipes-kernel/bcm43340/bcm43340-fw.bb
@@ -22,7 +22,9 @@ PR = "r5"
 
 FILES_${PN} += "/lib/firmware/brcm/* ${base_libdir}/systemd/system/bluetooth_attach.service"
 
-inherit allarch update-alternatives
+inherit allarch update-alternatives systemd
+
+SYSTEMD_SERVICE_${PN} = "bluetooth_attach.service"
 
 do_install() {
         install -v -d  ${D}/lib/firmware/brcm/


### PR DESCRIPTION
We need the --experimental configure switch enabled so that
when building bluez5 we also have the btattach binary required
for making bluetooth work on the Intel Edison with kernel 4.x

Signed-off-by: Florin Sarbu <florin@resin.io>