### PR TITLE
linux-yocto-edison.bb: Replace reset request command sent to SCU

### DIFF
--- a/recipes-kernel/linux/files/0003-Replace-reset-type-command-for-SCU.patch
+++ b/recipes-kernel/linux/files/0003-Replace-reset-type-command-for-SCU.patch
@@ -1,0 +1,27 @@
+From 7006278a40b9a23fbc1a9ea7bbb7c2cb7368fc9c Mon Sep 17 00:00:00 2001
+From: Sebastian Panceac <spanceac@resin.io>
+Date: Mon, 12 Feb 2018 15:29:49 +0100
+Subject: [PATCH] Replace reset type command for SCU
+
+Upstream-Status: Pending
+Signed-off-by: Sebastian Panceac <spanceac@resin.io>
+---
+ arch/x86/platform/intel-mid/intel-mid.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/x86/platform/intel-mid/intel-mid.c b/arch/x86/platform/intel-mid/intel-mid.c
+index 12a2725..d2b2e9f 100644
+--- a/arch/x86/platform/intel-mid/intel-mid.c
++++ b/arch/x86/platform/intel-mid/intel-mid.c
+@@ -79,7 +79,7 @@ static void intel_mid_power_off(void)
+ 
+ static void intel_mid_reboot(void)
+ {
+-	intel_scu_ipc_simple_command(IPCMSG_COLD_BOOT, 0);
++	intel_scu_ipc_simple_command(IPCMSG_COLD_RESET, 0);
+ }
+ 
+ static unsigned long __init intel_mid_calibrate_tsc(void)
+-- 
+2.7.4
+

--- a/recipes-kernel/linux/linux-yocto-edison.bb
+++ b/recipes-kernel/linux/linux-yocto-edison.bb
@@ -6,6 +6,7 @@ SRC_URI = " \
     git://github.com/resin-os/linux-edison;protocol=https;branch=eds-4.13 \
     file://0001-Add-kernel-parameter-to-enable-i2c_6-pinctrl-mapping.patch \
     file://0002-Enable-pwm0-1-2-3-pinmux-on-Edison-board.patch \
+    file://0003-Replace-reset-type-command-for-SCU.patch \
     "
 
 SRCREV = "54f9552249b720ef9d33a7eb9e0d1f8f53ce1025"


### PR DESCRIPTION
On boards where the Edison module is powered from 3.3V the reboot command hangs.
The SCU, which is a helper MCU on Edison boards, is responisble with the reboot.
This patch changes the reset request command sent to the SCU at reboot time, from IPCMSG_COLD_BOOT to
IPCMSG_COLD_RESET. This is the way the old Edison kernel was doing it, where reboot also worked on 3.3V.

Signed-off-by: Sebastian Panceac <spanceac@resin.io>