### PR TITLE
fstab: Add noauto, x-systemd.automount options to /factory

### DIFF
--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -4,4 +4,4 @@ devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 usbdevfs             /proc/bus/usb        usbdevfs   noauto                0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
 tmpfs                /var/volatile        tmpfs      defaults              0  0
-/dev/mmcblk0p5       /factory             auto       ro,noatime            0  0
+/dev/mmcblk0p5       /factory             auto       ro,noatime,noauto,x-systemd.automount            0  0


### PR DESCRIPTION
Without these parameters systemd halts before reloading
system manager configuration, and outputs:

You are in emergency mode. After logging in,
type "journalctl -xb" to view system logs,
"systemctl reboot" to reboot, "systemctl default" or "exit"
to boot into default mode. Press Enter for maintenance
(or press Control-D to continue):

Control-D needs to be pressed to continue system startup and
thus permitting the device to appear in the dashboard.

Signed-off-by: Vicentiu Galanopulo <vicentiu@resin.io>