### PR TITLE
edison.conf: Add PREFERRED_VERSION for dtc to 1.4.5

### DIFF
--- a/conf/machine/edison.conf
+++ b/conf/machine/edison.conf
@@ -19,6 +19,7 @@ IMAGE_ROOTFS_SIZE ?= "1521664"
 PREFERRED_PROVIDER_virtual/bootloader ?=  "u-boot"
 PREFERRED_VERSION_u-boot ?= "2015.10"
 PREFERRED_VERSION_u-boot-fw-utils ?= "2015.10"
+PREFERRED_VERSION_dtc = "1.4.5"
 UBOOT_MACHINE = "edison_config"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "u-boot u-boot-fw-utils kernel-modules sst-fw mcu-fw-bin mcu-fw-load"

--- a/recipes-kernel/dtc/dtc.inc
+++ b/recipes-kernel/dtc/dtc.inc
@@ -1,0 +1,25 @@
+SUMMARY = "Device Tree Compiler"
+HOMEPAGE = "https://devicetree.org/"
+DESCRIPTION = "The Device Tree Compiler is a tool used to manipulate the Open-Firmware-like device tree used by PowerPC kernels."
+SECTION = "bootloader"
+LICENSE = "GPLv2 | BSD"
+DEPENDS = "flex-native bison-native"
+
+SRC_URI = "git://git.kernel.org/pub/scm/utils/dtc/dtc.git \
+           file://make_install.patch \
+           file://0001-checks-Use-proper-format-modifier-for-size_t.patch \
+           "
+UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+(\.\d+)+)"
+
+EXTRA_OEMAKE='NO_PYTHON=1 PREFIX="${prefix}" LIBDIR="${libdir}" DESTDIR="${D}"'
+
+S = "${WORKDIR}/git"
+
+do_install () {
+	oe_runmake install
+}
+
+PACKAGES =+ "${PN}-misc"
+FILES_${PN}-misc = "${bindir}/convert-dtsv0 ${bindir}/ftdump ${bindir}/dtdiff"
+
+RDEPENDS_${PN}-misc += "bash diffutils"

--- a/recipes-kernel/dtc/dtc/0001-checks-Use-proper-format-modifier-for-size_t.patch
+++ b/recipes-kernel/dtc/dtc/0001-checks-Use-proper-format-modifier-for-size_t.patch
@@ -1,0 +1,43 @@
+From c7a4c3817796107bb824a1f173faf90fae45396b Mon Sep 17 00:00:00 2001
+From: Thierry Reding <treding@nvidia.com>
+Date: Wed, 27 Sep 2017 15:04:09 +0200
+Subject: [PATCH] checks: Use proper format modifier for size_t
+
+The size of size_t can vary between architectures, so using %ld isn't
+going to work on 32-bit builds. Use the %zu modifier to make sure it is
+always correct.
+
+Upstream-Status: Backport
+Signed-off-by: Thierry Reding <treding@nvidia.com>
+Acked-by: Rob Herring <robh@kernel.org>
+Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ checks.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/checks.c b/checks.c
+index 902f2e3..08a3a29 100644
+--- a/checks.c
++++ b/checks.c
+@@ -972,7 +972,7 @@ static void check_property_phandle_args(struct check *c,
+ 	int cell, cellsize = 0;
+ 
+ 	if (prop->val.len % sizeof(cell_t)) {
+-		FAIL(c, dti, "property '%s' size (%d) is invalid, expected multiple of %ld in node %s",
++		FAIL(c, dti, "property '%s' size (%d) is invalid, expected multiple of %zu in node %s",
+ 		     prop->name, prop->val.len, sizeof(cell_t), node->fullpath);
+ 		return;
+ 	}
+@@ -1163,7 +1163,7 @@ static void check_interrupts_property(struct check *c,
+ 		return;
+ 
+ 	if (irq_prop->val.len % sizeof(cell_t))
+-		FAIL(c, dti, "property '%s' size (%d) is invalid, expected multiple of %ld in node %s",
++		FAIL(c, dti, "property '%s' size (%d) is invalid, expected multiple of %zu in node %s",
+ 		     irq_prop->name, irq_prop->val.len, sizeof(cell_t),
+ 		     node->fullpath);
+ 
+-- 
+2.15.0
+

--- a/recipes-kernel/dtc/dtc/make_install.patch
+++ b/recipes-kernel/dtc/dtc/make_install.patch
@@ -1,0 +1,17 @@
+Upstream-Status: Inappropriate [configuration]
+
+Index: git/Makefile
+===================================================================
+--- git.orig/Makefile
++++ git/Makefile
+@@ -168,8 +168,8 @@ install-bin: all $(SCRIPTS)
+ install-lib: all
+ 	@$(VECHO) INSTALL-LIB
+ 	$(INSTALL) -d $(DESTDIR)$(LIBDIR)
+-	$(INSTALL) $(LIBFDT_lib) $(DESTDIR)$(LIBDIR)
+-	ln -sf $(notdir $(LIBFDT_lib)) $(DESTDIR)$(LIBDIR)/$(LIBFDT_soname)
++	$(INSTALL) $(LIBFDT_lib) $(DESTDIR)$(LIBDIR)/$(LIBFDT_soname)
++	ln -sf $(LIBFDT_soname) $(DESTDIR)$(LIBDIR)/$(notdir $(LIBFDT_lib))
+ 	ln -sf $(LIBFDT_soname) $(DESTDIR)$(LIBDIR)/libfdt.$(SHAREDLIB_EXT)
+ 	$(INSTALL) -m 644 $(LIBFDT_archive) $(DESTDIR)$(LIBDIR)
+ 

--- a/recipes-kernel/dtc/dtc_1.4.5.bb
+++ b/recipes-kernel/dtc/dtc_1.4.5.bb
@@ -1,0 +1,10 @@
+require dtc.inc
+
+LIC_FILES_CHKSUM = "file://GPL;md5=94d55d512a9ba36caa9b7df079bae19f \
+		    file://libfdt/libfdt.h;beginline=3;endline=52;md5=fb360963151f8ec2d6c06b055bcbb68c"
+
+SRCREV = "22a65c5331c22979d416738eb756b9541672e00d"
+
+S = "${WORKDIR}/git"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The update to thud/warrior needs this set
as u-boot will not compile with the current
dtc package from poky warrior.

Changelog-entry: Set preferred dtc version to 1.4.5
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>