### PR TITLE
systemd_%.bbappend: Copy system.conf to {sysconfdir}/systemd

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -7,6 +7,4 @@ FILES_${PN} += "${sysconfdir}/systemd/network/*"
 do_install_append_edison () {
 	install -d ${D}${sysconfdir}/systemd/network/
 	install -m 0644 ${WORKDIR}/*.network ${D}${sysconfdir}/systemd/network/
-
-	sed -i -e 's/#RuntimeWatchdogSec=0/RuntimeWatchdogSec=90/' ${D}${sysconfdir}/systemd/system.conf
 }


### PR DESCRIPTION
Without this copy command the build error is generated
| sed can't read /systemd/1_241+AUTOINC+c1f8ff8d0d-r0/image/etc/systemd/system.conf
No such file or directory

Changelog-entry: Copy system.conf to {sysconfdir}/systemd
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>